### PR TITLE
account를 전달 받는 과정을 GET에서 POST방식으로 변경했습니다.

### DIFF
--- a/src/main/java/team9/issue_manage_system/controller/AccountController.java
+++ b/src/main/java/team9/issue_manage_system/controller/AccountController.java
@@ -2,10 +2,7 @@ package team9.issue_manage_system.controller;
 
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team9.issue_manage_system.entity.Account;
 import team9.issue_manage_system.repository.AccountRepository;
 
@@ -17,17 +14,23 @@ import java.util.Optional;
 public class AccountController {
     private final AccountRepository accountRepository;
 
-    @GetMapping(value = "/userfind/{id}") //user 찾기
-    public Optional<Account> findUser(@PathVariable("id") String id) { // 먼저 존재여부를 파악하고 Optional을 써야할 듯
-        return accountRepository.findById(id);
+    @PostMapping("/userFind")
+    public Optional<Account> findUser(@RequestBody Account account){
+        return accountRepository.findById(account.getId());
     }
 
-    @GetMapping("/useradd/{id},{password}")
-    public void uploadAccount(@PathVariable("id") String id, @PathVariable("password") String password){
-        Account account = new Account(id, password); //수정필요
+    /**
+     * ID 중복 여부 확인 : 존재하면 true, 새로운 경우 false
+     * @param account : Account타입의 클래스 (이 부분은 수정 필요 : ID체크에는 Password가 없으므로)
+     */
+    @PostMapping("/userIdCheck")
+    public Boolean findUserIdCheck(@RequestBody Account account){
+        return accountRepository.existsById(account.getId());
+    }
 
-        accountRepository.save(account);
-        //return accountRepository.findAll();
-        //public List<Account>
+    @PostMapping("/userAdd")
+    public void uploadAccount(@RequestBody Account account){
+        Account account1 = new Account(account.getId(), account.getPassword(), "tester");
+        accountRepository.save(account1);
     }
 }


### PR DESCRIPTION
일부 전달 도메인을 케멀케이스에 맞게 수정했습니다.
아이디 체크를 하는 함수를 추가했습니다.
실행 여부는 확인하지 못하였습니다.

- 일단 실행 여부를 알 수가 없어서 확인을 할 수 없지만, 
- 통신 방법에 변화를 주었습니다.
- 1. 로그인과 관련된 정보들은 모두 민감한 정보이므로, GET방식에서 POST방식으로 변경했습니다.
- 이 과정에서 전달할 도메인의 이름을 일부 변경하거나 추가했습니다. 
- 유저의 로그인 정보를 확인하는 함수의 경로 : /userFind
- 유저의 회원가입 시도의 아이디 중복을 확인하는 함수의 경로 : /userIdCheck
- 유저의 회원가입시 DB에 추가하는 함수의 경로 : /userAdd

- 로그인과 관련된 모든 부분들이 구현된 것이 아니므로 확인 부탁드립니다.
- 미구현한 부분
- 로그인 정보(로그인과 비밀번호)를 모두 확인하는 부분
- 실질적으로 로그인 정보를 클라이언트에게 전송하는 부분
- 실제 작동하는 지 여부

- Issue를 탐색하는 코드를 일부 작성했으나, main과 충돌하는 바람에 폐기했습니다.